### PR TITLE
switch to rain component

### DIFF
--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="visualization">
-    <DragNDrop />
+    <Rain />
   </div>
 </template>
 
@@ -9,7 +9,7 @@
 export default {
     name: 'Visualization',
     components: {
-      DragNDrop: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/DragNDrop2")
+      Rain: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/rain")
     },
     computed: {
     },


### PR DESCRIPTION
Switch to the `rain` component instead of the `DragNDrop` component, as that component is missing `.svg` and `.png` dependencies in the `assets/images` folder